### PR TITLE
Small memory leak resolved

### DIFF
--- a/pulsator4droid/src/main/java/pl/bclogic/pulsator4droid/library/PulsatorLayout.java
+++ b/pulsator4droid/src/main/java/pl/bclogic/pulsator4droid/library/PulsatorLayout.java
@@ -370,6 +370,16 @@ public class PulsatorLayout extends RelativeLayout {
         }
     }
 
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+
+        if (mAnimatorSet != null) {
+            mAnimatorSet.cancel();
+            mAnimatorSet = null;
+        }
+    }
+
     private class PulseView extends View {
 
         public PulseView(Context context) {


### PR DESCRIPTION
Detected on Kitkat via LeakCanary when an activity is destroyed, the animator was keeping a reference to it. Seems to resolve it.
