### PR TITLE
Bug fix for PulsatorLayout not animating on view out of window

### DIFF
--- a/pulsator4droid/src/main/java/pl/bclogic/pulsator4droid/library/PulsatorLayout.java
+++ b/pulsator4droid/src/main/java/pl/bclogic/pulsator4droid/library/PulsatorLayout.java
@@ -375,8 +375,16 @@ public class PulsatorLayout extends RelativeLayout {
         super.onDetachedFromWindow();
 
         if (mAnimatorSet != null) {
-            mAnimatorSet.cancel();
-            mAnimatorSet = null;
+            stop();
+        }
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        if (mAnimatorSet != null) {
+            start();
         }
     }
 


### PR DESCRIPTION
This happens when the view is inside any scrollable view ie, ScrollView, RecyclerView, ListView, etc.

start and stop animation onAttachedToWindow and onDetachedFromWindow respectively