### PR TITLE
Added the ability to set the repeat parameter programatically

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=1.0.3
+VERSION_NAME=1.0.4

--- a/pulsator4droid/src/main/java/pl/bclogic/pulsator4droid/library/PulsatorLayout.java
+++ b/pulsator4droid/src/main/java/pl/bclogic/pulsator4droid/library/PulsatorLayout.java
@@ -213,6 +213,25 @@ public class PulsatorLayout extends RelativeLayout {
         }
     }
 
+
+    /**
+     * Set number of pulse repeats
+     * Defaults ot INFINITE
+     */
+    public void setRepeat(int repeat){
+        if (repeat < 0) {
+            throw new IllegalArgumentException("Repeat cannot be negative");
+        }
+
+        if (repeat != mRepeat) {
+            mRepeat = repeat;
+            reset();
+            invalidate();
+        }
+
+    }
+
+
     /**
      * Gets the current color of the pulse effect in integer
      * Defaults to Color.rgb(0, 116, 193);


### PR DESCRIPTION
I was using the PulsatorLayout programmatically, and needed to get access to the repeat variable, otherwise it would default to infinite. 
